### PR TITLE
Parsing fails when providing port with hostname.

### DIFF
--- a/lib/haproxy/treetop/config.treetop
+++ b/lib/haproxy/treetop/config.treetop
@@ -116,7 +116,7 @@ module HAProxy::Treetop
     end
 
     rule dns_host
-      [a-zA-Z\-\.] 4..255 <Host>
+      [a-zA-Z\-\.\d] 4..255 <Host>
     end
 
     rule proxy_name

--- a/spec/fixtures/multi-pool.haproxy.cfg
+++ b/spec/fixtures/multi-pool.haproxy.cfg
@@ -52,3 +52,4 @@ backend logs
 	server fake_logger 127.0.0.1:9999 backup
 	server prd_log_1 10.245.174.75:8000 cookie i-prd_log_1 check inter 3000 rise 2 fall 3 maxconn 1000
 	server prd_log_2 10.215.157.10:8000 cookie i-prd_log_2 check inter 3000 rise 2 fall 3 maxconn 1000
+        server prd_log_3 cloudloghost1:8000 cookie i-prd_log_2 check inter 3000 rise 2 fall 3 maxconn 1000    

--- a/spec/haproxy/parser_spec.rb
+++ b/spec/haproxy/parser_spec.rb
@@ -12,7 +12,7 @@ describe "HAProxy::Parser" do
       @config.backends.size.should == 2
       logs_backend = @config.backend('logs')
 
-      logs_backend.servers.size.should == 3
+      logs_backend.servers.size.should == 4
 
       server1 = logs_backend.servers['prd_log_1']
       server1.name.should == 'prd_log_1'
@@ -27,6 +27,11 @@ describe "HAProxy::Parser" do
       server3 = logs_backend.servers['prd_log_2']
       server3.name.should == 'prd_log_2'
       server3.host.should   == '10.215.157.10'
+      server3.port.should == '8000'
+
+      server3 = logs_backend.servers['prd_log_3']
+      server3.name.should == 'prd_log_3'
+      server3.host.should   == 'cloudloghost1'
       server3.port.should == '8000'
     end
   end


### PR DESCRIPTION
It is correct for only a single ':' to be there for a service address assuming IPV4. This was failing on a simple hostname and port example. This PR fixes #5.
