### PR TITLE
Issue #19: add Underscore to the allowed Characters for Keyword-String.

### DIFF
--- a/lib/haproxy/treetop/config.treetop
+++ b/lib/haproxy/treetop/config.treetop
@@ -88,7 +88,7 @@ module HAProxy::Treetop
     end
 
     rule keyword
-       (("errorfile" / "timeout") whitespace)? [a-z0-9\-\.]+ <Keyword>
+       (("errorfile" / "timeout") whitespace)? [a-z0-9_\-\.]+ <Keyword>
     end
 
     rule server_name


### PR DESCRIPTION
Issue #19: add Underscore to allowed Characters for Keyword-String.  
	modified:   lib/haproxy/treetop/config.treetop